### PR TITLE
Remove requirement for OCP_PULL_SECRET_FILE for ARO deprovision

### DIFF
--- a/aro/destroy.sh
+++ b/aro/destroy.sh
@@ -55,11 +55,6 @@ if [ -z "$AZURE_BASE_DOMAIN" ]; then
     missing=1
 fi
 
-if [ -z "$OCP_PULL_SECRET_FILE" ]; then
-    printf "${RED}OCP_PULL_SECRET_FILE env var not set. flagging for exit.${CLEAR}\n"
-    missing=1
-fi
-
 if [ "$missing" -ne 0 ]; then
     exit $missing
 fi


### PR DESCRIPTION
## Summary of Changes

ARO's destroy currently requires OCP_PULL_SECRET_FILE to be set, but it is not required - so we can remove this check!