### PR TITLE
Patch ROSA cleanup

### DIFF
--- a/aro/provision.sh
+++ b/aro/provision.sh
@@ -284,6 +284,7 @@ jq --arg username "${username}" '. + {USERNAME: $username}' ${STATE_FILE} > .tmp
 jq --arg password "${password}" '. + {PASSWORD: $password}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 jq --arg console_url "${console_url}" '. + {CONSOLE_URL: $console_url}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 jq --arg api_url "${api_url}" '. + {API_URL: $api_url}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
+jq --arg identity_provider "kube:admin" '. + {IDENTITY_PROVIDER: $identity_provider}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 cat > ${CREDS_FILE} <<EOF
 {
     "USERNAME": "${username}",

--- a/rosa/destroy.sh
+++ b/rosa/destroy.sh
@@ -34,13 +34,15 @@ if [ ! -f "$1" ]; then
     exit 1
 fi
 CLUSTER_NAME=$(cat $1 | jq -r '.CLUSTER_NAME')
-REGION=$(cat $1 | jq -r '.REGION')
 PLATFORM=$(cat $1 | jq -r '.PLATFORM')
 USERNAME=$(cat $1 | jq -r '.USERNAME')
 PASSWORD=$(cat $1 | jq -r '.PASSWORD')
 CONSOLE_URL=$(cat $1 | jq -r '.CONSOLE_URL')
 API_URL=$(cat $1 | jq -r '.API_URL')
 AWS_ACCOUNT_ID=$(cat $1 | jq -r '.AWS_ACCOUNT_ID')
+
+# Export AWS_REGION as it is used under the covers by the aws cli
+export AWS_REGION=$(cat $1 | jq -r '.REGION')
 
 # Set a skipped flag that we'll set if we skip any deletions.  Used to skip deletion of state files.
 skipped=0

--- a/rosa/destroy.sh
+++ b/rosa/destroy.sh
@@ -13,6 +13,17 @@ if [[ "$COLOR" == "False" || "$COLOR" == "false" ]]; then
     YELLOW='\e[39m'
 fi
 
+# Check for vendored or global 'rosa' cli
+if [[ $(which rosa) ]]; then
+    ROSA=$(which rosa)
+elif [[ -x $PWD/vendor/rosa ]]; then
+    ROSA=$PWD/vendor/rosa
+else
+    printf "${RED}'rosa' CLI not found globally or vendored, run install.sh to set up dependencies.${CLEAR}\n"
+    exit 1
+fi
+printf "${BLUE}Using 'rosa' CLI installed at ${ROSA}${CLEAR}\n"
+
 #----LOAD ENV VARS FROM INPUT FILE----#
 if [ -z "$1" ]; then
     printf "Usage: ./destroy.sh <path-to-json-file>\n"
@@ -67,13 +78,13 @@ fi
 #----LOG IN----#
 printf "${BLUE}Logging in to the 'rosa' cli.${CLEAR}\n"
 printf "${YELLOW}"
-rosa login --token=${ROSA_TOKEN}
+${ROSA} login --token=${ROSA_TOKEN}
 printf "${CLEAR}"
 
 
 #-----VALIDATE THE AWS ACCOUNT ID-----#
 printf "${BLUE}Validate that the user is logged into the AWS account that hold the ${CLUSTER_NAME} cluster.${CLEAR}\n"
-current_aws_id=$(rosa whoami | grep "AWS Account ID:" | sed -n "s/AWS Account ID:[ ]*\(.*\)/\1/p")
+current_aws_id=$(${ROSA} whoami | grep "AWS Account ID:" | sed -n "s/AWS Account ID:[ ]*\(.*\)/\1/p")
 if [[ "${current_aws_id}" != "${AWS_ACCOUNT_ID}" ]]; then
     printf "${YELLOW}The current AWS account ID (${current_aws_id}) doesn't match the ID of the account where ${CLUSTER_NAME} was created.${CLEAR}\n"
     printf "${YELLOW}Make sure you're logged in to the same account (ID: ${AWS_ACCOUNT_ID}) that was used to create ${CLUSTER_NAME} and re-run.${CLEAR}\n"
@@ -87,14 +98,14 @@ fi
 #-----LOG THE DEPROVISIONER-----#
 printf "${BLUE}Cluster will be deprovisioned as:${CLEAR}\n"
 printf "${BLUE}"
-rosa whoami
+${ROSA} whoami
 printf "${CLEAR}"
 
 
 #-----DELETE THE CLUSTER-----#
 printf "${BLUE}Launching the cluster deprovision for ${CLUSTER_NAME}.${CLEAR}\n"
 printf "${YELLOW}"
-rosa delete cluster --cluster=${CLUSTER_NAME} --yes --watch
+${ROSA} delete cluster --cluster=${CLUSTER_NAME} --yes --watch
 printf "${CLEAR}"
 
 

--- a/rosa/install.sh
+++ b/rosa/install.sh
@@ -33,7 +33,7 @@ if [[ ! $(which aws) ]]; then
         # Linux
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip";
         unzip awscliv2.zip;
-        sudo ./aws/install;
+        ./aws/install;
         printf "${GREEN}Installed the aws CLI at $(which aws) with version:${CLEAR}\n";
         printf "${YELLOW}";
         aws --version;

--- a/rosa/provision.sh
+++ b/rosa/provision.sh
@@ -130,7 +130,7 @@ printf "${CLEAR}"
 
 
 #----WRITE INITIAL STATE FILE----#
-printf "${BLUE}Writing inital state before starting provision.${CLEAR}"
+printf "${BLUE}Writing inital state before starting provision.${CLEAR}\n"
 if [[ ! -f ${STATE_FILE} ]]; then
     echo "{}" > ${STATE_FILE}
 fi

--- a/rosa/provision.sh
+++ b/rosa/provision.sh
@@ -178,6 +178,7 @@ jq --arg api_url "${api_url}" '. + {API_URL: $api_url}' ${STATE_FILE} > .tmp; mv
 jq --arg aws_account_id "${aws_account_id}" '. + {AWS_ACCOUNT_ID: $aws_account_id}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 jq --arg username "${username}" '. + {USERNAME: $username}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 jq --arg password "${password}" '. + {PASSWORD: $password}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
+jq --arg identity_provider "Cluster-Admin" '. + {IDENTITY_PROVIDER: $identity_provider}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 printf "${GREEN}ROSA cluster named ${RESOURCE_NAME} provisioned successfully.\n${CLEAR}"
 printf "${GREEN}Console URL: ${console_url}\n${CLEAR}"
 printf "${GREEN}API URL: ${api_url}\n${CLEAR}"

--- a/rosa/provision.sh
+++ b/rosa/provision.sh
@@ -165,7 +165,7 @@ aws_account_id=$(${ROSA} describe cluster --cluster=${RESOURCE_NAME} | grep "AWS
 
 
 #-----CONFIGURE AUTH-----#
-printf "${BLUE}Creating an admin user.${CLEAR}\n"
+printf "${BLUE}Creating an admin user on ${RESOURCE_NAME}.${CLEAR}\n"
 ${ROSA} create admin --cluster=${RESOURCE_NAME} > .tmp_creds
 username=$(cat .tmp_creds | grep "username" | sed -n "s/.*--username[ ]*\([^ ]*\)[ ]*.*/\1/p")
 password=$(cat .tmp_creds | grep "password" | sed -n "s/.*--password[ ]*\([^ ]*\)[ ]*.*/\1/p")

--- a/rosa/provision.sh
+++ b/rosa/provision.sh
@@ -137,7 +137,9 @@ fi
 jq --arg cluster_name "${RESOURCE_NAME}" '. + {CLUSTER_NAME: $cluster_name}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 jq --arg region "${AWS_REGION}" '. + {REGION: $region}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 jq --arg platform "rosa" '. + {PLATFORM: $platform}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
-
+# Load account ID and log in JSON to ensure that cleanup is successful if provision fails
+aws_account_id=$(${ROSA} whoami | grep "AWS Account ID:" | sed -n "s/AWS Account ID:[ ]*\(.*\)/\1/p")
+jq --arg aws_account_id "${aws_account_id}" '. + {AWS_ACCOUNT_ID: $aws_account_id}' ${STATE_FILE} > .tmp; mv .tmp ${STATE_FILE};
 
 #-----PROVISION CLUSTER AND WATCH LOGS-----#
 printf "${BLUE}Provisioning the ROSA cluster ${RESOURCE_NAME} in ${AWS_REGION}.${CLEAR}\n"
@@ -158,6 +160,7 @@ printf "${CLEAR}"
 #-----EXTRACT DETAILS-----#
 api_url=$(${ROSA} describe cluster --cluster=${RESOURCE_NAME} | grep "API URL:" | sed -n "s/API URL:[ ]*\(.*\)/\1/p")
 console_url=$(${ROSA} describe cluster --cluster=${RESOURCE_NAME} | grep "Console URL:" | sed -n "s/Console URL:[ ]*\(.*\)/\1/p")
+# Update account ID logged earlier to match that of the cluster (just in case)
 aws_account_id=$(${ROSA} describe cluster --cluster=${RESOURCE_NAME} | grep "AWS Account:" | sed -n "s/AWS Account:[ ]*\(.*\)/\1/p")
 
 


### PR DESCRIPTION
## Summary of Changes

This PR patches ROSA cleanup by setting the `AWS_REGION` field in the environment and adds the export of an IDENTITY_PROVIDER field for use by consumers who want to log in via automation in the web ui and need to know the identity provider (which isn't `kube:admin` on ROSA).  