### PR TITLE
Add dex IDP provision

### DIFF
--- a/osd-aws/README.md
+++ b/osd-aws/README.md
@@ -16,6 +16,12 @@ export AWS_SECRET_ACCESS_KEY=<your AWS secret access key>
 export AWS_REGION=<region>  # defaults to us-east-1
 export AWS_NODE_COUNT=<number> # defaults to 3
 
+export IDP_ISSUER_URL=<https://sso...>
+export IDP_ISSUER_LOGIN_SERVER=<https://api...>
+export IDP_ISSUER_LOGIN_TOKEN=<service account login token>
+
+export GITHUB_USER=<github user to be authorized as admin>
+
 # Optional
 
 export CLUSTER_NAME=<some cluster name> # if you set a cluster name, we will use it as a base name for all resources created and append a unique identifier
@@ -24,17 +30,10 @@ export CLUSTER_NAME=<some cluster name> # if you set a cluster name, we will use
 ```
 
 2. run `./provision.sh`
-3. if successful, you will see a `.json` file with metadata for your cluster!
-4. You will then need to run the following commands interactively:
+3. if successful, you will see a `.json` and a `.yaml` file with metadata for your cluster!
+4. You can log into your cluster using your github ID and 2 factor authentication.
 
 ```
-ocm create idp --cluster=<cluster_id>  <-- choose github, follow the prompts, give your app permission in github
-ocm create user <github user> --cluster=<cluster_id> --group=cluster-admins
-ocm create user <github user> --cluster=<cluster_id> --group=dedicated-admins
-Log in to your cluster, get the login token
-oc login
-```
-...and now you have a kubeconifg with your credentials.
 
 ### Cleaning up a cluster
 1. run `./destroy.sh <.json file of your cluster metadata>`

--- a/osd-aws/dex-idp-config.yaml.template
+++ b/osd-aws/dex-idp-config.yaml.template
@@ -1,0 +1,11 @@
+apiVersion: dex.betssongroup.com/v1
+kind: Client
+metadata:
+  name: __CLUSTER_NAME__
+  namespace: sso
+spec:
+  name: __CLUSTER_NAME__
+  secret: __CLUSTER_ID__-__CLUSTER_ID__
+  public: false
+  redirectURIs:
+    - "https://oauth-openshift.apps.__CLUSTER_NAME__.__CLUSTER_DOMAIN__/oauth2callback/openid-1"

--- a/osd-aws/provision.sh
+++ b/osd-aws/provision.sh
@@ -152,4 +152,4 @@ cat > $(pwd)/${OSDAWS_CLUSTER_NAME}.json <<EOF
 EOF
 
 printf "${GREEN}Cluster provision successful.  Cluster named ${OSDAWS_CLUSTER_NAME} created. \n"
-printf "State files saved for cleanup in $(pwd)/${OSDAWS_CLUSTER_NAME}.json and $(pwd)/dex-idp-config.yaml.${CLEAR}\n"
+printf "State files saved for cleanup in $(pwd)/${OSDAWS_CLUSTER_NAME}.json and $(pwd)/${OSDAWS_CLUSTER_NAME}.yaml.${CLEAR}\n"

--- a/osd-gcp/.gitignore
+++ b/osd-gcp/.gitignore
@@ -1,3 +1,4 @@
 *.kubeconfig
 *.json
 *.yaml
+*.64

--- a/osd-gcp/README.md
+++ b/osd-gcp/README.md
@@ -11,6 +11,10 @@ This module can be used to install dependencies for OpenShift Dedicated on GCP (
 ```
 export GCLOUD_CREDS_FILE=<path to your osd-ccs-admin service account json>
 export OCM_TOKEN=<Red Hat OCM token>
+export IDP_ISSUER_URL=<https://sso...>
+export IDP_ISSUER_LOGIN_SERVER=<https://api...>
+export IDP_ISSUER_LOGIN_TOKEN=<service account login token>
+export GITHUB_USER=<github user to be authorized as admin>
 
 # Optional
 export GCLOUD_REGION=<Google Cloud region, defaults to "us-east1">
@@ -23,17 +27,7 @@ export CLUSTER_NAME=<some cluster name> # if you set a cluster name, we will use
 ```
 
 2. run `./provision.sh`
-3. if successful, you will see a `.json` file with metadata for your cluster!
-4. You will then need to run the following commands interactively:
-
-```
-ocm create idp --cluster=<cluster_id>  <-- choose github, follow the prompts, give your app permission in github
-ocm create user <github user> --cluster=<cluster_id> --group=cluster-admins
-ocm create user <github user> --cluster=<cluster_id> --group=dedicated-admins
-Log in to your cluster, get the login token
-oc login
-```
-...and now you have a kubeconifg with your credentials.
+3. if successful, you will see a `.json` and a `.yaml` file with metadata for your cluster!
 
 ### Cleaning up a cluster
 1. run `./destroy.sh <.json file of your cluster metadata>`

--- a/osd-gcp/destroy.sh
+++ b/osd-gcp/destroy.sh
@@ -16,6 +16,15 @@ if [ ! -f "$1" ]; then
     printf "$1 does not exist, exiting\n"
     exit 1
 fi
+
+YAML_DIR=`dirname $1`
+YAML_FILE=`basename $1 .json`
+IDP_YAML_FILENAME=$YAML_DIR/$YAML_FILE.yaml
+if [ ! -f "$IDP_YAML_FILENAME" ]; then
+    printf "$IDP_YAML_FILENAME does not exist, exiting\n"
+    exit 1
+fi
+
 CLUSTER_NAME=$(cat $1 | jq -r '.CLUSTER_NAME')
 CLUSTER_ID=$(cat $1 | jq -r '.CLUSTER_ID')
 REGION=$(cat $1 | jq -r '.REGION')
@@ -53,11 +62,15 @@ fi
 #----DELETE OCM-GCP CLUSTER----#
 printf "${BLUE}Deleting the OCM-GCP cluster named ${CLUSTER_NAME}.${CLEAR}\n"
 
-printf "${YELLOW}"
 ocm delete /api/clusters_mgmt/v1/clusters/$CLUSTER_ID
 if [ "$?" -ne 0 ]; then
     printf "${RED}Failed to delete cluster ${CLUSTER_NAME}, exiting${CLEAR}\n"
     exit 1
 fi
+
+oc login --token=$IDP_SERVICE_ACCOUNT_TOKEN --server=$IDP_ISSUER_LOGIN_SERVER
+oc delete -f $IDP_YAML_FILENAME
+oc logout
+
 printf "${CLEAR}"
 printf "${GREEN}Successfully cleaned up the cluster named ${CLUSTER_NAME}.${CLEAR}\n"

--- a/osd-gcp/dex-idp-config.yaml.template
+++ b/osd-gcp/dex-idp-config.yaml.template
@@ -1,0 +1,11 @@
+apiVersion: dex.betssongroup.com/v1
+kind: Client
+metadata:
+  name: __CLUSTER_NAME__
+  namespace: sso
+spec:
+  name: __CLUSTER_NAME__
+  secret: __CLUSTER_ID__-__CLUSTER_ID__
+  public: false
+  redirectURIs:
+    - "https://oauth-openshift.apps.__CLUSTER_NAME__.__CLUSTER_DOMAIN__/oauth2callback/openid-1"

--- a/osd-gcp/provision.sh
+++ b/osd-gcp/provision.sh
@@ -20,7 +20,6 @@ else
   USER=${USER:-"jenkins"}
 fi
 
-
 SHORTNAME=$(echo $USER | head -c 7)
 
 # Generate a default resource name
@@ -30,7 +29,8 @@ NAME_SUFFIX="odgc"
 # Default to us-east1
 GCLOUD_REGION=${GCLOUD_REGION:-"us-east1"}
 GCLOUD_NODE_COUNT=${GCLOUD_NODE_COUNT:-"3"}
-GCLOUD_MACHINE_TYPE=${GCLOUD_MACHINE_TYPE:-"n1-standard-4"}
+GCLOUD_MACHINE_TYPE=${GCLOUD_MACHINE_TYPE:-"custom-4-16384"}
+# was: GCLOUD_MACHINE_TYPE=${GCLOUD_MACHINE_TYPE:-"n1-standard-4"}
 
 # OCM_URL can be one of: 'production', 'staging', 'integration'
 OCM_URL=${OCM_URL:-"production"}
@@ -72,106 +72,71 @@ fi
 #----CREATE CLUSTER----#
 OSDGCP_CLUSTER_NAME="${RESOURCE_NAME}-${NAME_SUFFIX}"
 printf "${BLUE}Creating an OSD cluster on GCP named ${OSDGCP_CLUSTER_NAME}.${CLEAR}\n"
-printf "${YELLOW}"
-
-OPTIONAL_PARAMS=""
 
 ocm create cluster --ccs --service-account-file $GCLOUD_CREDS_FILE --provider gcp --region $GCLOUD_REGION --compute-machine-type $GCLOUD_MACHINE_TYPE --compute-nodes $GCLOUD_NODE_COUNT $OSDGCP_CLUSTER_NAME
 if [ "$?" -ne 0 ]; then
     printf "${RED}Failed to provision cluster. See error above. Exiting${CLEAR}\n"
     exit 1
 fi
-printf "${GREEN}Successfully provisioned cluster ${OSDGCP_CLUSTER_NAME}.${CLEAR}\n"
 
-CLUSTER_ID=`ocm list clusters --parameter search="name like '${OSDGCP_CLUSTER_NAME}'" --no-headers | awk  '{ print $1 }'`
+CLUSTER_NAME=$OSDGCP_CLUSTER_NAME
 
-#----Make KUBECONFIG that is useable from anywhere ----#
-export KUBECONFIG_SAVED=$KUBECONFIG
-export KUBECONFIG=$(pwd)/${OSDGCP_CLUSTER_NAME}.kubeconfig
+printf "${GREEN}Successfully provisioned cluster ${CLUSTER_NAME}.${CLEAR}\n"
 
-# Check for which base64 command we have available so we can use the right option
-echo | base64 -w 0 > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-  # GNU coreutils base64, '-w' supported
-  BASE64_OPTION=" -w 0"
-else
-  # Openssl base64, no wrapping by default
-  BASE64_OPTION=" "
-fi
+printf "${GREEN}Cluster name: '${CLUSTER_NAME}${CLEAR}'\n"
 
-echo | kubectl apply -f - &> /dev/null <<EOF
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cluster-admin
-  namespace: kube-system
-EOF
+CLUSTER_ID=`ocm list clusters --parameter search="name like '${CLUSTER_NAME}'" --no-headers | awk  '{ print $1 }'`
+printf "${GREEN}Cluster ID: '${CLUSTER_ID}${CLEAR}'\n"
 
-echo | kubectl apply -f - &> /dev/null <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kube-system-cluster-admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: cluster-admin
-  namespace: kube-system
-EOF
+CLUSTER_DOMAIN=`ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID | jq -r '.dns.base_domain'`
+printf "${GREEN}Cluster domain: '${CLUSTER_DOMAIN}${CLEAR}'\n"
 
-sleep 1
+sed -e "s;__CLUSTER_NAME__;$CLUSTER_NAME;g" \
+    -e "s;__CLUSTER_ID__;$CLUSTER_ID;g" \
+    -e "s;__CLUSTER_DOMAIN__;$CLUSTER_DOMAIN;g" \
+                dex-idp-config.yaml.template \
+                > $(pwd)/${OSDGCP_CLUSTER_NAME}.yaml
 
-cat > "$(pwd)/${OSDGCP_CLUSTER_NAME}.kubeconfig.portable" <<EOF
-apiVersion: v1
-clusters:
-- cluster:
-    server: $(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
-    insecure-skip-tls-verify: true
-  name: $(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
-contexts:
-- context:
-    cluster: $(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
-    namespace: default
-    user: kube-system-cluster-admin/$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
-  name: kube-system-cluster-admin/$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
-current-context: kube-system-cluster-admin/$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
-kind: Config
-preferences: {}
-users:
-- name: kube-system-cluster-admin/$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
-  user:
-    token: $(kubectl get $(kubectl get secret -n kube-system -o name | grep cluster-admin-token | head -n 1) -n kube-system -o jsonpath={.data.token} | base64 -d ${BASE64_OPTION})
-EOF
+oc login --token=$IDP_SERVICE_ACCOUNT_TOKEN --server=$IDP_ISSUER_LOGIN_SERVER
+oc apply -f $(pwd)/${OSDGCP_CLUSTER_NAME}.yaml
+oc logout
 
-# take portable kubeconfig and replace original kubeconfig
-cp $(pwd)/${OSDGCP_CLUSTER_NAME}.kubeconfig.portable $(pwd)/${OSDGCP_CLUSTER_NAME}.kubeconfig
-rm $(pwd)/${OSDGCP_CLUSTER_NAME}.kubeconfig.portable
+# Configure IDP and users
+NAMELEN=`printf "%02x\n" ${#GITHUB_USER}`
+printf "%b" '\x0a' > username.encoded
+printf "%b" '\x'$NAMELEN >> username.encoded
+printf "%s" $GITHUB_USER >> username.encoded
+printf "%b" '\x12\x06' >> username.encoded
+printf "%s" 'github' >> username.encoded
+base64 username.encoded | sed 's/\=$//' > username.64
+rm username.encoded
 
-# Set KUBECONFIG to what it used to be
-export KUBECONFIG=$KUBECONFIG_SAVED
+# Need to loop over this - to wait until it comes available
 
+while ! ocm create idp --cluster=$CLUSTER_ID --type openid --client-id  $CLUSTER_NAME --client-secret $CLUSTER_ID-$CLUSTER_ID --issuer-url $IDP_ISSUER_URL --email-claims email --name-claims fullName,name --username-claims fullName,preferred_username,email,name
+do
+    printf "${YELLOW}Waiting for cluster to become active...${CLEAR}\n"
+    sleep 30
+done
 
+printf "${GREEN}Adding github user ${GITHUB_USER} as admin.${CLEAR}\n"
+
+ocm create user `cat username.64` --cluster=$CLUSTER_ID --group=cluster-admins
+ocm create user `cat username.64` --cluster=$CLUSTER_ID --group=dedicated-admins
+rm username.64
 
 #-----DUMP STATE FILE----#
+LOGIN_URL=https://console-openshift-console.apps.$OSDGCP_CLUSTER_NAME.$CLUSTER_DOMAIN
 cat > $(pwd)/${OSDGCP_CLUSTER_NAME}.json <<EOF
 {
     "CLUSTER_NAME": "${OSDGCP_CLUSTER_NAME}",
     "CLUSTER_ID": "${CLUSTER_ID}",
     "REGION": "${GCLOUD_REGION}",
-    "URL": "${OCM_URL}",
+    "OCM_URL": "${OCM_URL}",
+    "LOGIN_URL": "${LOGIN_URL}",
     "PLATFORM": "OSD-GCP"
 }
 EOF
-
-
-#----EXTRACTING KUBECONFIG----#
-printf "${GREEN}You can find your kubeconfig file for this cluster in $(pwd)/${OSDGCP_CLUSTER_NAME}.kubeconfig\n${CLEAR}"
-printf "${CLEAR}"
-
-
 
 printf "${GREEN}Cluster provision successful.  Cluster named ${OSDGCP_CLUSTER_NAME} created. \n"
 printf "State file saved for cleanup in $(pwd)/${OSDGCP_CLUSTER_NAME}.json${CLEAR}\n"

--- a/osd-gcp/provision.sh
+++ b/osd-gcp/provision.sh
@@ -139,4 +139,5 @@ cat > $(pwd)/${OSDGCP_CLUSTER_NAME}.json <<EOF
 EOF
 
 printf "${GREEN}Cluster provision successful.  Cluster named ${OSDGCP_CLUSTER_NAME} created. \n"
-printf "State file saved for cleanup in $(pwd)/${OSDGCP_CLUSTER_NAME}.json${CLEAR}\n"
+printf "State files saved for cleanup in $(pwd)/${OSDGCP_CLUSTER_NAME}.json and $(pwd)/${OSDGCP_CLUSTER_NAME}.yaml.${CLEAR}\n"
+


### PR DESCRIPTION
Here's what we have for OSD - through dex, we can provision a user based on a github ID, and they have admin privileges, but since it's 2FA through github... we can't really `oc login` _a priori_ without navigating to the web and copying a login token.