### PR TITLE
Add versioning to ARO deployment

### DIFF
--- a/aro/README.md
+++ b/aro/README.md
@@ -33,6 +33,10 @@ export CLUSTER_NAME=<some cluster name>
 # if CLUSTER_NAME is not specified, we will use the first 8 characters of the system's username
 
 export AZURE_REGION=<region>  # defaults to eastus
+
+export CLUSTER_VERSION=<cluster version>
+# To get the range of supported versions: az aro get-versions --location <region>
+# If defined, will use the version, otherwise will use the latest available version
 ```
 
 2. run `./provision.sh`

--- a/aro/provision.sh
+++ b/aro/provision.sh
@@ -147,6 +147,23 @@ az account show
 printf "${CLEAR}"
 
 
+#----Set optional params----#
+OPTIONAL_PARAMS=""
+#----Set cluster version if defined----#
+if [ ! -z "$CLUSTER_VERSION" ]; then
+    vers=$(az aro get-versions --location "$AZURE_REGION" -o tsv)
+    if echo "$vers" | grep -q "$CLUSTER_VERSION"; then
+        printf "${BLUE}Using $CLUSTER_VERSION as cluster version.${CLEAR}\n"
+        OPTIONAL_PARAMS=$"${OPTIONAL_PARAMS} --version ${CLUSTER_VERSION} "
+    else
+        printf "${RED}Given cluster version is not supported - $CLUSTER_VERSION.${CLEAR}\n"
+        printf "${RED}The following versions supported by ARO:${CLEAR}\n"
+        printf "${RED}$vers${CLEAR}\n"
+        exit 1
+    fi
+fi
+
+
 #----REGISTER RESOURCE PROVIDERS----#
 printf "${BLUE}Enabling the Microsoft.RedHatOpenShift Resource Provider.${CLEAR}\n"
 az provider register -n Microsoft.RedHatOpenShift --wait
@@ -276,7 +293,7 @@ az aro create \
     --worker-count "$AZURE_WORKER_COUNT" \
     --worker-vm-disk-size-gb "$AZURE_WORKER_DISK_SIZE" \
     --domain=${RESOURCE_NAME}.${AZURE_BASE_DOMAIN} \
-    --pull-secret @${OCP_PULL_SECRET_FILE};
+    --pull-secret @${OCP_PULL_SECRET_FILE} ${OPTIONAL_PARAMS};
 printf "${CLEAR}"
 
 


### PR DESCRIPTION
ARO provides number of cluster versions that could be used during deployment to specify a version the is required.
Add "CLUSTER_VERSION" environment variable to specify the cluster version that should be used.
The parameter is optional.